### PR TITLE
[documentation] added links to javadocs & updated github action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,8 +45,8 @@ jobs:
           gradle javadoc
           mkdir -p ../pages-out/java-docs/client/html/
           mkdir -p ../pages-out/java-docs/client/core/
-          mv html/build/docs/* ../pages-out/java-docs/client/html/
-          mv core/build/docs/* ../pages-out/java-docs/client/core/
+          mv html/build/docs/javadoc/* ../pages-out/java-docs/client/html/
+          mv core/build/docs/javadoc/* ../pages-out/java-docs/client/core/
         # zip -r html/build/docs/client-html-javadocs.zip html/build/docs/* 
         # zip -r core/build/docs/client-core-javadocs.zip core/build/docs/* 
 

--- a/documentation/Writerside/topics/Introduction.md
+++ b/documentation/Writerside/topics/Introduction.md
@@ -1,8 +1,7 @@
 # Introduction
 
 Fantasy-Chess ist a PvP, turn-based action game, in which players command characters
-to fight against each other in order to claim victory. The game is fought out on a 
-9x9 Board that 
+to fight against each other in order to claim victory.
 
 ## Getting Started
 
@@ -71,6 +70,15 @@ Repeat the previous step for the <code>fantasychess-server</code> and <code>fant
 You are now ready to start working on the Project.
 </p>
 </procedure>
+
+## JavaDocs
+
+Since the entire project is written in Java, it makes heavy use of JavaDocs, automatic deploys of the current dev docs can be found here:
+
+- [Client / HTML](https://b-team-organisation.github.io/Fantasy-Chess/java-docs/client/html/)
+- [Client / Core](https://b-team-organisation.github.io/Fantasy-Chess/java-docs/client/core/)
+- [Common](https://b-team-organisation.github.io/Fantasy-Chess/java-docs/common/)
+- [Server](https://b-team-organisation.github.io/Fantasy-Chess/java-docs/server/)
 
 ## Team
 


### PR DESCRIPTION
Added an easy access to JavaDocs in the introduction and fixed a location issue with the javadocs where the client docs still contained: javadoc a second time